### PR TITLE
Handle Netatmo request timeouts gracefully

### DIFF
--- a/lib/netatmo-request.js
+++ b/lib/netatmo-request.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const NETWORK_ERROR_CODES = new Set([
+    'ECONNABORTED',
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'EHOSTUNREACH',
+    'ENETDOWN',
+    'ENETUNREACH',
+    'ENOTFOUND',
+    'ESOCKETTIMEDOUT',
+    'ETIMEDOUT',
+]);
+
+/**
+ * @param {unknown} error
+ * @returns {error is Error & { code: string }}
+ */
+function isNetworkError(error) {
+    return error instanceof Error && 'code' in error && NETWORK_ERROR_CODES.has(String(error.code));
+}
+
+module.exports = { REQUEST_TIMEOUT_MS, isNetworkError };

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const utils = require('@iobroker/adapter-core');
 const url = require('node:url');
 const moment = require('moment');
 const request = require('request');
+const { REQUEST_TIMEOUT_MS, isNetworkError } = require('./lib/netatmo-request');
 // const { Adapter } = require('@iobroker/adapter-core');
 
 let logger;
@@ -54,7 +55,7 @@ class NetatmoCrawler extends utils.Adapter {
         }
 
         try {
-            let token = await this.getAuthorizationToken(this);
+            const token = await this.getAuthorizationToken(this);
             for (const [counter, stationUrl] of stationUrls.entries()) {
                 this.log.debug(`Working with stationUrl: ${stationUrl}`);
                 if (stationUrl) {
@@ -76,9 +77,14 @@ class NetatmoCrawler extends utils.Adapter {
             //         sentryInstance.getSentryObject().captureException(e);
             //     }
             // }
-            this.log.error(`Error while running Netatmo Crawler. Error Message:${e}`);
+            if (isNetworkError(e)) {
+                this.log.warn(`Could not retrieve new Netatmo data due to a network problem: ${e.message}`);
+            } else {
+                this.log.error(`Error while running Netatmo Crawler. Error Message:${e}`);
+            }
             this.log.debug('all done, exiting');
-            this.terminate ? this.terminate(15) : process.exit(15);
+            const exitCode = isNetworkError(e) ? 0 : 15;
+            this.terminate ? this.terminate('Netatmo data retrieval finished', exitCode) : process.exit(exitCode);
         }
     }
 
@@ -331,17 +337,18 @@ class NetatmoCrawler extends utils.Adapter {
                             'User-Agent': 'Mozilla/5.0',
                         },
                         rejectUnauthorized: false,
+                        timeout: REQUEST_TIMEOUT_MS,
                     },
 
                     async function (error, response, body) {
                         if (error) {
-                            rej(error);
+                            return rej(error);
                         }
                         //logger.debug('Body:' + body);
 
                         if (!body) {
                             await adapter.saveState(tokenState, null);
-                            rej('No body for authorization token found.');
+                            return rej('No body for authorization token found.');
                         }
                         try {
                             logger.debug(`Body:${body}`);
@@ -376,10 +383,11 @@ class NetatmoCrawler extends utils.Adapter {
                     json: {
                         device_id: stationId,
                     },
+                    timeout: REQUEST_TIMEOUT_MS,
                 },
                 async function (error, response, body) {
                     if (error) {
-                        rej(error);
+                        return rej(error);
                     }
                     if (body && body.body) {
                         logger.debug(`Body:${JSON.stringify(body.body)}`);
@@ -465,16 +473,17 @@ class NetatmoCrawler extends utils.Adapter {
                         Authorization: token,
                     },
                     json: inputObj,
+                    timeout: REQUEST_TIMEOUT_MS,
                 },
                 async function (error, response, body) {
                     if (error) {
-                        rej(error);
+                        return rej(error);
                     }
                     logger.debug(`Body Rain_Today:${JSON.stringify(body)}`);
                     if (body && body.body) {
                         if (!body.body[0] || !body.body[0].value) {
                             logger.debug(`No rain today value for Station ${stationId}`);
-                            res('');
+                            return res('');
                         }
                         //console.log('Body:' + JSON.stringify(responseBody, null, 4));
                         try {
@@ -521,10 +530,11 @@ class NetatmoCrawler extends utils.Adapter {
                         Authorization: token,
                     },
                     json: inputObj,
+                    timeout: REQUEST_TIMEOUT_MS,
                 },
                 async function (error, response, body) {
                     if (error) {
-                        rej(error);
+                        return rej(error);
                     }
                     if (body && body.body) {
                         logger.debug(`Body Rain_Yesterday:${JSON.stringify(body.body)}`);
@@ -574,10 +584,11 @@ class NetatmoCrawler extends utils.Adapter {
                         Authorization: token,
                     },
                     json: inputObj,
+                    timeout: REQUEST_TIMEOUT_MS,
                 },
                 async function (error, response, body) {
                     if (error) {
-                        rej(error);
+                        return rej(error);
                     }
                     if (body && body.body) {
                         logger.debug(`Body Rain_LastHour:${JSON.stringify(body.body)}`);

--- a/main.test.js
+++ b/main.test.js
@@ -1,30 +1,20 @@
 'use strict';
 
-/**
- * This is a dummy TypeScript test file using chai and mocha
- *
- * It's automatically excluded from npm and its build output is excluded from both git and npm.
- * It is advised to test all your modules with accompanying *.test.js-files
- */
-
-// tslint:disable:no-unused-expression
-
 const { expect } = require('chai');
-// import { functionToTest } from "./moduleToTest";
+const { REQUEST_TIMEOUT_MS, isNetworkError } = require('./lib/netatmo-request');
 
-describe('module to test => function to test', () => {
-	// initializing logic
-	const expected = 5;
+describe('Netatmo request handling', () => {
+    it('limits every request to 30 seconds', () => {
+        expect(REQUEST_TIMEOUT_MS).to.equal(30_000);
+    });
 
-	it(`should return ${expected}`, () => {
-		const result = 5;
-		// assign result a value from functionToTest
-		expect(result).to.equal(expected);
-		// or using the should() syntax
-		result.should.equal(expected);
-	});
-	// ... more tests => it
+    for (const code of ['ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ENETUNREACH', 'ENOTFOUND']) {
+        it(`treats ${code} as an expected network problem`, () => {
+            expect(isNetworkError(Object.assign(new Error('network unavailable'), { code }))).to.equal(true);
+        });
+    }
 
+    it('does not downgrade programming errors to warnings', () => {
+        expect(isNetworkError(new TypeError('unexpected response'))).to.equal(false);
+    });
 });
-
-// ... more test suites => describe


### PR DESCRIPTION
## What changed

- add a 30-second timeout to every external Netatmo HTTP request
- stop request callbacks immediately after rejection
- log expected timeout, DNS, and connectivity failures as warnings
- terminate scheduled runs with exit code 0 for expected network failures so the next run can start normally
- retain error logging and a non-zero exit code for unexpected/programming failures
- replace the placeholder unit test with coverage for timeout configuration and network-error classification

## Root cause

The adapter used HTTP requests without a timeout. If Netatmo or the internet connection stopped responding, the scheduled adapter process could remain alive indefinitely. Every later schedule invocation then reported that the instance was already running.

## User impact

A temporary Netatmo or internet outage now produces a warning that no fresh data could be retrieved. The run exits cleanly after the timeout, allowing the following scheduled run to retry automatically.

- Fix #57 